### PR TITLE
Feature/63 bug stage clear 객체 생성 stage4 상태 get 수정

### DIFF
--- a/sever/src/main/java/com/example/rememberdokdo/Dto/StageProgressResponseDto.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Dto/StageProgressResponseDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class StageProgressResponseDto {
-    private int progressId;         // 진행 상태 ID
+    private Integer progressId;         // 진행 상태 ID
     private String sessionId;       // 세션 ID
     private int remainingHearts;    // 남은 하트
     private boolean isCleared;      // 스테이지 클리어 여부

--- a/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
@@ -48,7 +48,17 @@ public class StageService {
 
     // 스테이지 클리어 상태 저장
     public SessionProgressDto clearStage(String sessionId, int stageId) {
-    // 스테이지 1이 클리어되지 않은 상태에서 2, 3, 4를 시도할 경우 예외 처리
+
+        // 이미 클리어된 스테이지인지 확인
+        boolean isAlreadyCleared = stageProgressRepository.findBySessionIdAndStageId(sessionId, stageId)
+                .map(StageProgressEntity::isCleared)
+                .orElse(false);
+
+        if (isAlreadyCleared) {
+            throw new IllegalStateException("이미 클리어된 스테이지입니다.");
+        }
+
+        // 스테이지 1이 클리어되지 않은 상태에서 2, 3, 4를 시도할 경우 예외 처리
         if (stageId >= 2 && stageId <= 4) {
             boolean isStage1Cleared = stageProgressRepository.findBySessionIdAndStageId(sessionId, 1)
                     .map(StageProgressEntity::isCleared)

--- a/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
@@ -182,9 +182,19 @@ public class StageService {
 
     // GET 요청: 스테이지 상태 조회
     public StageProgressResponseDto getStageStatus(String sessionId, int stageId) {
+        // 스테이지 정보를 조회
         StageProgressEntity stageProgress = stageProgressRepository
                 .findBySessionIdAndStageId(sessionId, stageId)
-                .orElseThrow(() -> new IllegalArgumentException("스테이지 진행 정보가 없습니다."));
+                .orElse(null);
+
+        if (stageProgress == null) {
+            return StageProgressResponseDto.builder()
+                    .progressId(null) // null 허용
+                    .sessionId(sessionId)
+                    .remainingHearts(3) // 초기 하트 수
+                    .isCleared(false)
+                    .build();
+        }
 
         return StageProgressResponseDto.builder()
                 .progressId(stageProgress.getProgressId())

--- a/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
@@ -117,6 +117,15 @@ public class StageService {
 
     //스테이지 4,5,6 미션 도전 처리
     public StageProgressResponseDto processItem(String sessionId, int stageId, String selectedItem) {
+        // 이미 클리어된 스테이지인지 확인
+        boolean isAlreadyCleared = stageProgressRepository.findBySessionIdAndStageId(sessionId, stageId)
+                .map(StageProgressEntity::isCleared)
+                .orElse(false);
+
+        if (isAlreadyCleared) {
+            throw new IllegalStateException("이미 클리어된 스테이지입니다.");
+        }
+
         // 이전 스테이지의 상태에서 남은 하트를 가져오거나, 기본값 3 설정 (스테이지 4는 무조건 기본값 3)
         int previousHearts;
         if (stageId == 4) {


### PR DESCRIPTION
### #️⃣ Related Issue
> ex) #63 

### 📝 Work Detail

> -스테이지 클리어 했으면 해당 스테이지에 대한 클리어 요청이 또 되었을 때 이미 클리어 되었다고 알려주기 (알려주고 POST 안되게 막기)
스테이지 4에 접근했을 때 stage4 하트 수 상태 점검해야되는데 GET 요청을 하면 500 에러 해결

### ScreenShots (선택)
![스크린샷 2024-11-23 225937](https://github.com/user-attachments/assets/31d9c210-61a5-4428-b818-d337083508bf)
에러 메시지 띄워 주기 (중복 처리 해결)

![스크린샷 2024-11-23 232841](https://github.com/user-attachments/assets/ad481743-525c-4633-aa9c-87a60bad8a44)
초기화 완료 !

테스트 과정은 '디버깅 과정' 페이지 확인해주세요 !!
