### PR TITLE
Feature/63 bug stage clear 객체 생성 stage4 상태 get 수정

### DIFF
--- a/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
@@ -204,7 +204,7 @@ public class StageService {
                 StageProgressEntity previousStage = stageProgressRepository.findBySessionIdAndStageId(sessionId, stageId - 1)
                         .orElse(null);
 
-                if (!previousStage.isCleared()) {
+                if (previousStage == null || !previousStage.isCleared()) {
                     // 이전 스테이지가 클리어되지 않은 경우 예외 발생
                     throw new IllegalArgumentException("이전 스테이지를 클리어하지 않았습니다. sessionId: " + sessionId + ", stageId: " + (stageId - 1));
                 }


### PR DESCRIPTION
### #️⃣ Related Issue
> ex) #66 

### 📝 Work Detail
> 스테이지 진행 정보가 존재하면, 해당 정보를 반환하고 스테이지 진행 정보가 없는 경우에 기본 하트 수 설정 (3)하도록 함. 그리고 이전 스테이지 상태 확인하여 클리어하지 않으면 예외 발생 시킴 !! 클리어 했으면 남은 하트를 가져와 설정.

> **자세한 내용은 노션 페이지에 테스트 과정 첨부해놨으니 확인해주세요 !!**