### PR TITLE
Feat: 스테이지7 클리어 기능 추가

### DIFF
--- a/sever/src/main/java/com/example/rememberdokdo/Controller/StageController.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Controller/StageController.java
@@ -28,6 +28,10 @@ public class StageController {
     // 스테이지 클리어 정보 저장
     @PostMapping("/{stageId}/clear")
     public SessionProgressDto clearStage(@RequestParam String sessionId, @PathVariable("stageId") int stageId) {
+        if (stageId == 7) {
+            // 스테이지 7 전용 메서드 호출
+            return stageService.clearStageForStage7(sessionId);
+        }
         return stageService.clearStage(sessionId, stageId);
     }
 

--- a/sever/src/main/java/com/example/rememberdokdo/Dto/StageProgressResponseDto.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Dto/StageProgressResponseDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class StageProgressResponseDto {
-    private int progressId;         // 진행 상태 ID
+    private Integer progressId;         // 진행 상태 ID
     private String sessionId;       // 세션 ID
     private int remainingHearts;    // 남은 하트
     private boolean isCleared;      // 스테이지 클리어 여부

--- a/sever/src/main/java/com/example/rememberdokdo/Service/SessionService.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Service/SessionService.java
@@ -137,7 +137,7 @@ public class SessionService {
         List<SessionProgressDto.StageStatus> stages = stageProgressRepository.findBySessionId(sessionId).stream()
                 .map(stage -> {
                     // 스테이지 4, 5, 6에 대해서만 remainingHearts 추가
-                    Integer remainingHearts = (stage.getStageId() >= 4 && stage.getStageId() <= 6)
+                    Integer remainingHearts = (stage.getStageId() >= 4 && stage.getStageId() <= 7)
                             ? stage.getRemainingHearts() // 남은 하트 가져오기
                             : null;
 

--- a/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
+++ b/sever/src/main/java/com/example/rememberdokdo/Service/StageService.java
@@ -192,7 +192,7 @@ public class StageService {
             if (stageId > 4) {
                 // 이전 스테이지 정보 조회
                 StageProgressEntity previousStage = stageProgressRepository.findBySessionIdAndStageId(sessionId, stageId - 1)
-                        .orElse(null);
+                        .orElseThrow(() -> new IllegalArgumentException("스테이지 진행 정보가 없습니다. "));
 
                 if (previousStage == null || !previousStage.isCleared()) {
                     // 이전 스테이지가 클리어되지 않은 경우 예외 발생


### PR DESCRIPTION
### #️⃣ Related Issue
> ex) #69 

### 📝 Work Detail

> Stage 7 (퍼즐게임) 성공 로직 추가하고, 프론트와 연동하면서 기존에 배포된 코드 모두 옮겼습니다! 스테이지 7까지 클리어하면 이전 하트 값도 받아와지고 세션 상태 확인에서도 확인 가능합니다 (테스트 모두 마쳤어요)

### Test
![image](https://github.com/user-attachments/assets/36e73bf4-c270-45b2-a727-c864ff644cae)
세션 발급 받고

스테이지 1,2,3,4,5,6까지 클리어하고 세션 상태
```
{
  "sessionId": "8084b3f1-5040-4a20-af9e-9c6d4bdfd5e8",
  "userId": null,
  "stages": [
    {
      "stageId": 1,
      "remainingHearts": null,
      "cleared": true
    },
    {
      "stageId": 2,
      "remainingHearts": null,
      "cleared": true
    },
    {
      "stageId": 3,
      "remainingHearts": null,
      "cleared": true
    },
    {
      "stageId": 4,
      "remainingHearts": 3,
      "cleared": true
    },
    {
      "stageId": 5,
      "remainingHearts": 3,
      "cleared": true
    },
    {
      "stageId": 6,
      "remainingHearts": 2,
      "cleared": true
    }
  ],
  "inventory": [],
  "expiresAt": "2024-11-25T23:50:31",
  "isActive": true
}
```
그리고 스테이지 7 클리어 보내면 **stage/7/clear?sessionId=8084b3f1-5040-4a20-af9e-9c6d4bdfd5e8'**

```
{
  "sessionId": "8084b3f1-5040-4a20-af9e-9c6d4bdfd5e8",
  "userId": null,
  "stages": [
    {
      "stageId": 7,
      "remainingHearts": 2,
      "cleared": true
    }
  ],
  "inventory": null,
  "expiresAt": "2024-11-25T23:52:42.4312981",
  "isActive": true
}
```
이렇게 응답 생성합니다.
이후, 세션 상태 확인 다시 해도 스테이지 7까지 모두 나오며 StageProgress 디비에도
![image](https://github.com/user-attachments/assets/93cf3786-6051-475d-84b4-8c12da986acc)
이렇게 나오는거 확인 가능합니다 !



### 💬 Review Requirements

> 49 수현이 브랜치에 merge하고 싶어요!
